### PR TITLE
Added small wrapper function to integrate over meshes

### DIFF
--- a/src/MatsubaraFunctions.jl
+++ b/src/MatsubaraFunctions.jl
@@ -33,6 +33,7 @@ module MatsubaraFunctions
     include("func/func.jl")
     include("boilerplate/boilerplate.jl")
     include("symmetries/symmetries.jl")
+    include("misc/integrate.jl")
     include("misc/mpi_helpers.jl")
     include("misc/pade.jl")
     include("misc/triqs_interface.jl")

--- a/src/mesh/brillouin/brillouin_mesh.jl
+++ b/src/mesh/brillouin/brillouin_mesh.jl
@@ -102,6 +102,15 @@ function reverse(m :: Mesh{MeshPoint{BrillouinPoint{N}}, BrillouinDomain{N, P}})
     return lin_idxs(m).reverse
 end
 
+"""
+    function volume_element(m :: Mesh{MeshPoint{BrillouinPoint{N}}, BrillouinDomain{N, P}}) :: Float64 where {N, P}
+
+Returns volume element of mesh
+"""
+function volume_element(m :: Mesh{MeshPoint{BrillouinPoint{N}}, BrillouinDomain{N, P}}) :: Float64 where {N, P}
+    return 1. / length(m)
+end
+
 # conversion from reciprocal to euclidean coordinates
 #-------------------------------------------------------------------------------#
 

--- a/src/mesh/index/index_mesh.jl
+++ b/src/mesh/index/index_mesh.jl
@@ -70,6 +70,15 @@ function Base.:values(m :: Mesh{MeshPoint{Index}, IndexDomain}) :: Vector{Int}
     return plain_value.(points(m))
 end
 
+"""
+    function volume_element(m :: Mesh{MeshPoint{Index}, IndexDomain}) :: Float64
+
+Returns volume element of mesh
+"""
+function volume_element(m :: Mesh{MeshPoint{Index}, IndexDomain}) :: Float64
+    return 1.
+end
+
 # bounds checking
 #-------------------------------------------------------------------------------#
 

--- a/src/mesh/matsubara/matsubara_mesh.jl
+++ b/src/mesh/matsubara/matsubara_mesh.jl
@@ -165,6 +165,15 @@ function Base.:values(m :: Mesh{MeshPoint{MatsubaraFrequency{PT}}, MatsubaraDoma
     return plain_value.(points(m))
 end
 
+"""
+    function volume_element(m :: Mesh{MeshPoint{MatsubaraFrequency{PT}}, MatsubaraDomain}) :: Float64 where {PT <: AbstractParticle}
+
+Returns volume element of mesh
+"""
+function volume_element(m :: Mesh{MeshPoint{MatsubaraFrequency{PT}}, MatsubaraDomain}) :: Float64 where {PT <: AbstractParticle}
+    return temperature(m)
+end
+
 # bounds checking
 #-------------------------------------------------------------------------------#
 

--- a/src/misc/integrate.jl
+++ b/src/misc/integrate.jl
@@ -1,0 +1,5 @@
+function integrate(f :: Function, m :: MT) where {MT <: AbstractMesh}
+    return volume_element(m) * sum(f, m)
+end
+
+export integrate


### PR DESCRIPTION
This pull request introduces a new mesh integration utility and adds a standardized way to compute the volume element for different mesh types. The main changes include the addition of the `integrate` function and the implementation of the `volume_element` function for several mesh types, allowing for consistent numerical integration across the codebase.

**Integration utility:**
* Added new `integrate` function in `misc/integrate.jl`, which computes the integral of a function over a mesh using its volume element.
* Included `misc/integrate.jl` in the main module file `src/MatsubaraFunctions.jl` to make the integration utility available throughout the package.

**Mesh volume element implementations:**
* Implemented `volume_element` for `BrillouinMesh`, returning the reciprocal of the mesh length for use in integration.
* Implemented `volume_element` for `IndexMesh`, returning 1 for each mesh point.
* Implemented `volume_element` for `MatsubaraMesh`, returning the mesh temperature as the volume element.